### PR TITLE
fix: @gabrielzilmar/event-emitter's url readjusted for public use

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//npm.pkg.github.com/:_authToken=${PKG_TOKEN}
-@gabrielzilmar:registry=https://npm.pkg.github.com
-always-auth=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -967,9 +967,8 @@
     },
     "node_modules/@gabrielzilmar/event-emitter": {
       "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@gabrielzilmar/event-emitter/0.0.1/0b7f775808f3a592e8c8eff3fc6e24912b471116",
-      "integrity": "sha512-0eWWGXNBHO+n9cMFRD/soOXQ7CNJdJwIdPvKwoJyowrhhWufr1DK7GnXcPgilUw7RWEYTmSZD9RQz4xkn+fG/A==",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@gabrielzilmar/event-emitter/-/event-emitter-0.0.1.tgz",
+      "integrity": "sha512-3zu5ZQjMb5PjJjSXodJWLQ5eUn+481wZ/VCPLvQ2u/sXp+VnGtQ/L75bISE3D6wooZm4MZKn2Pq+LyjGtWHQQw==",
       "dependencies": {
         "reflect-metadata": "^0.1.13"
       }


### PR DESCRIPTION
- Dependency's URL at `package-lock.json` adjusted for public use.
- `.npmrc` file deleted.